### PR TITLE
Forgot to update the path of the IRC logo

### DIFF
--- a/dashboards/interview-graine/index.html
+++ b/dashboards/interview-graine/index.html
@@ -121,7 +121,7 @@ We talked to caregivers for this interview. Also check out interview Hekima (wit
     </div>
     <div class="col col-4 item">
         <figure class="text-center">
-            <img src="/img/blog/irc-logo.png">
+            <img src="./img/blog/irc-logo.png">
         </figure>
     </div>
     <div class="col col-4 item">


### PR DESCRIPTION
Forgot to update the path of the IRC logo on Graine, this should fix it.